### PR TITLE
OSGi bundle gets not installed when uploading SRP Browser Package

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -18,7 +18,7 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <install.target>/apps/acme/install</install.target>
+        <install.target>/apps/srp-tools/install</install.target>
     </properties>
 
     <!-- ====================================================================== -->


### PR DESCRIPTION
Fix packaging of osgi bundle - otherwise it gets not installed when the package is uploaded.